### PR TITLE
Allow specifying doctype in registry

### DIFF
--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -411,7 +411,7 @@ function download_registry(basepath)
         rm(joinpath(basepath, "DocumentationGeneratorRegistry"), force = true, recursive = true)
         cd(basepath)
         # FIXME: change URL to JuliaDocs/DocumentationGeneratorRegistry.git
-        run(`git clone --depth=1 git@github.com:pfitzseb/DocumentationGeneratorRegistry.git DocumentationGeneratorRegistry`)
+        run(`git clone --depth=1 https://github.com/pfitzseb/DocumentationGeneratorRegistry.git DocumentationGeneratorRegistry`)
         tomlpath = joinpath(basepath, "DocumentationGeneratorRegistry", "Registry.toml")
         @assert isfile(tomlpath)
         return tomlpath

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -163,9 +163,8 @@ function get_method_from_registry(pspec, registry, root)
     if isfile(registry)
         uuid = string(pspec.uuid)
         toml = Pkg.TOML.parsefile(registry)
-        docs = get(toml, "packages", Dict())
-        if haskey(docs, uuid)
-            pkg = docs[uuid]
+        if haskey(toml, uuid)
+            pkg = toml[uuid]
             if haskey(pkg, "method") && haskey(pkg, "location")
                 return (pkg["method"], pkg["location"])
             else
@@ -406,12 +405,12 @@ function installable_on_version(version = VERSION; registry=joinpath(homedir(), 
     allpkgs
 end
 
+const DOCS_REGISTRY = "https://github.com/JuliaDocs/DocumentationGeneratorRegistry.git"
 function download_registry(basepath)
     try
         rm(joinpath(basepath, "DocumentationGeneratorRegistry"), force = true, recursive = true)
         cd(basepath)
-        # FIXME: change URL to JuliaDocs/DocumentationGeneratorRegistry.git
-        run(`git clone --depth=1 https://github.com/pfitzseb/DocumentationGeneratorRegistry.git DocumentationGeneratorRegistry`)
+        run(`git clone --depth=1 $DOCS_REGISTRY DocumentationGeneratorRegistry`)
         tomlpath = joinpath(basepath, "DocumentationGeneratorRegistry", "Registry.toml")
         @assert isfile(tomlpath)
         return tomlpath

--- a/src/worker_work.jl
+++ b/src/worker_work.jl
@@ -4,7 +4,7 @@ using JSON
 
 include("DocumentationGenerator.jl")
 
-const GIT_TOKEN_FILE = if isfile(joinpath("/config/sync", "gh_auth.txt"))
+const GIT_TOKEN_FILE = if isfile(joinpath("config", "sync", "gh_auth.txt"))
     joinpath("/config/sync", "gh_auth.txt")
 else
     joinpath(@__DIR__, "gh_auth.txt")
@@ -30,6 +30,38 @@ function create_docs(pspec::Pkg.Types.PackageSpec, buildpath)
     _module, rootdir = DocumentationGenerator.install_and_use(pspec)
     pkgname = pspec.name
 
+    methods = DocumentationGenerator.parse_metadata_toml(rootdir)
+    @info methods
+    for method in methods
+        errored = false
+        type, uri = method
+        @info "$(pkgname) specifies docs of type $(type)"
+        out = try
+            if type == "git-repo"
+                @info("building `git-repo` docs")
+                build_git_docs(pkgname, rootdir, buildpath, uri)
+            elseif type == "hosted"
+                @info("building `hosted` docs")
+                build_hosted_docs(pkgname, rootdir, buildpath, uri)
+            elseif type == "vendored"
+                @info("building `vendored` docs")
+                build_local_dir_docs(pkgname, _module, rootdir, buildpath, uri)
+            else
+                @error("invalid doctype: $type")
+                :nope, ""
+            end
+        catch err
+            @error("Error building docs of type `$type`:", exception = err)
+            errored = true
+        end
+
+        if !errored
+            return out
+        end
+    end
+end
+
+function build_local_dir_docs(pkgname, _module, rootdir, buildpath, uri)
     # package doesn't load, so let's only use the README
     if _module === nothing
         return mktempdir() do root
@@ -41,7 +73,7 @@ function create_docs(pspec::Pkg.Types.PackageSpec, buildpath)
 
     # actual Documenter docs
     try
-        for docdir in joinpath.(rootdir, ("docs", "doc"))
+        for docdir in (uri, joinpath.(rootdir, ("docs", "doc"))...)
             if isdir(docdir)
                 makefile = joinpath(docdir, "make.jl")
                 # create customized makefile with removed deploydocs + modified makedocs
@@ -79,6 +111,49 @@ function contributor_user(dict)
     )
 end
 
+function build_hosted_docs(pkgname, rootdir, buildpath, uri)
+    # js redirect
+    open(joinpath(buildpath, "index.html"), "w") do io
+        println(io,
+            """
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+                    <script type="text/javascript">
+                        window.onload = function () {
+                            window.location.replace("$(uri)");
+                        }
+                    </script>
+                </head>
+                <body>
+                    Redirecting to <a href="$(uri)">$(uri)</a>.
+                </body>
+            </html>
+            """
+        )
+    end
+    # download search index
+    try
+        download(uri*"/search_index.js", joinpath(buildpath, "search_index.js"))
+    catch err
+        @error("search index download failed for $(uri)", exception = err)
+    end
+    return :real, rootdir
+end
+
+function build_git_docs(pkgname, rootdir, buildpath, uri)
+    mktempdir() do dir
+        cd(dir)
+        run(`git clone --depth=1 $(uri) docsource`)
+        docsproject = joinpath(dir, "docsource")
+        cd(docsproject)
+        build_local_dir_docs(pkgname, true, docsproject, buildpath, "")
+    end
+
+    return :real, rootdir
+end
+
 function package_docs(uuid, name, url, version, buildpath)
     pspec = PackageSpec(uuid = uuid, name = name, version = version)
     @info("Generating docs for $name")
@@ -111,12 +186,13 @@ function package_docs(uuid, name, url, version, buildpath)
              monkeypatchdocsearch(uuid, name, buildpath)
         end
     catch e
-        @error("Package $name didn't build", error = e)
+        @error("Package $name didn't build", error = e, stacktrace=stacktrace(catch_backtrace()))
         meta["installs"] = false
     end
 
     return meta
 end
+
 function monkeypatchdocsearch(uuid, name, buildpath)
     if !(get(ENV, "DISABLE_CENTRALIZED_SEARCH", false) in ("true", "1", 1))
         @info "monkey patching search.js for $(name)"

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 build
 logs
+DocumentationGeneratorRegistry

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ const julia = first(Base.julia_cmd())
 
 @test length(DocumentationGenerator.installable_on_version()) > 1500
 
-@testset "run with timeout" begin
+@testset "Running code with a timeout" begin
     let
         tempfile = tempname()
         str = """
@@ -59,7 +59,7 @@ const julia = first(Base.julia_cmd())
     end
 end
 
-@testset "documentation generation run" begin
+@testset "Documentation Generation" begin
     packages = [
         # without docs
         (
@@ -137,8 +137,7 @@ end
         for pkg in packages
             pkgbuild = joinpath(build, DocumentationGenerator.get_docs_dir(pkg.name, pkg.uuid))
             @test isdir(pkgbuild)
-            for (i, version) in enumerate(pkg.versions)
-                println(pkg.name, ": ", version)
+            @testset "$(pkg.name): $(version)" for (i, version) in enumerate(pkg.versions)
                 @test isfile(basepath, "logs", string(pkg.name, "-", pkg.uuid, " ", version, ".log"))
 
                 versiondir = joinpath(pkgbuild, string(version))
@@ -159,12 +158,21 @@ end
             end
         end
     end
-    @testset "log folder" begin
-
-    end
 end
 
-@testset "utils" begin
+@testset "Ruby Gems" begin
     @test isfile(DocumentationGenerator.find_ruby_gem("licensee"))
     @test isfile(DocumentationGenerator.find_ruby_gem("commonmarker"))
+end
+
+@testset "Documentation Registry" begin
+    mktempdir() do dir
+        reg = DocumentationGenerator.download_registry(dir)
+        @test isfile(reg)
+        toml = Pkg.TOML.parsefile(reg)
+        @test length(keys(toml)) > 0
+        @test haskey(toml, "e5e0dc1b-0480-54bc-9374-aad01c23163d")
+        junosettings = toml["e5e0dc1b-0480-54bc-9374-aad01c23163d"]
+        @test junosettings["method"] == "hosted"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,15 @@ end
             installs = [false, true, true],
             doctype = [nothing, "real", "real"],
         ),
+        # with hosted docs
+        (
+            name = "Juno",
+            url = "https://github.com/JunoLab/Juno.jl.git",
+            uuid = "e5e0dc1b-0480-54bc-9374-aad01c23163d",
+            versions = [v"0.7.0"],
+            installs = [true],
+            doctype = ["real"]
+        ),
     ]
 
     basepath = @__DIR__


### PR DESCRIPTION
With this PR package authors can specify how and where their docs are in https://github.com/JuliaDocs/DocumentationGeneratorRegistry.