### PR TITLE
WIP: better readme rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ matrix:
     - julia: nightly
 before_install:
   - sudo apt-get install ruby bundler cmake pkg-config git libssl-dev
-  - sudo gem install --no-ri --no-rdoc licensee
-  - sudo gem install --no-ri --no-rdoc commonmarker
+  - gem install --no-ri --no-rdoc licensee
+  - gem install --no-ri --no-rdoc commonmarker

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ matrix:
   allow_failures:
     - julia: nightly
 before_install:
-  - sudo apt-get install ruby bundler cmake pkg-config git libssl-dev && gem install --no-ri --no-rdoc licensee
+  - sudo apt-get install ruby bundler cmake pkg-config git libssl-dev
+  - sudo gem install --no-ri --no-rdoc licensee
+  - sudo gem install --no-ri --no-rdoc commonmarker

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 [![Build Status](https://travis-ci.org/JuliaDocs/DocumentationGenerator.jl.svg?branch=master)](https://travis-ci.org/JuliaDocs/DocumentationGenerator.jl)
 
 Generate documentation for *all the packages*.
+
+## Installation
+
+```
+pkg> install DocumentationGenerator
+```
+installs this package. Optionally you might want to install the `commonmarker` and `licensee` ruby
+gems for better license detection and GFM rendering:
+```
+$ gem install commonmarker
+$ gem install licensee
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate documentation for *all the packages*.
 ## Installation
 
 ```
-pkg> install DocumentationGenerator
+pkg> add DocumentationGenerator
 ```
 installs this package. Optionally you might want to install the `commonmarker` and `licensee` ruby
 gems for better license detection and GFM rendering:

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -55,10 +55,11 @@ end
 
 function rendergfm(file, fileout)
     try
-        redcarpet = expanduser("~/.gem/ruby/2.6.0/bin/redcarpet")
+        redcarpet = expanduser("~/.gem/ruby/2.6.0/bin/commonmarker")
         cmd = `$(redcarpet) $(file)`
         rendered = read(cmd, String)
         open(fileout, "w") do io
+            # lots of backticks so the @raw block doesn't end prematurely
             println(io, "````````````@raw html\n", rendered, "\n````````````")
         end
     catch err

--- a/src/worker_work.jl
+++ b/src/worker_work.jl
@@ -13,7 +13,8 @@ end
 function license(path::String, confidence=85)
     out = IOBuffer()
     err = IOBuffer()
-    cmd = `/usr/local/bin/licensee detect --json --confidence=$confidence $path`
+    licensee = DocumentationGenerator.find_ruby_gem("licensee")
+    cmd = `$licensee detect --json --confidence=$confidence $path`
     pipe = pipeline(cmd, stdout=out, stderr=err)
     try
         run(pipe)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,6 @@ const julia = first(Base.julia_cmd())
     end
 end
 
-
 @testset "documentation generation run" begin
     packages = [
         # without docs
@@ -154,4 +153,9 @@ end
     @testset "log folder" begin
 
     end
+end
+
+@testset "utils" begin
+    @test isfile(DocumentationGenerator.find_ruby_gem("licensee"))
+    @test isfile(DocumentationGenerator.find_ruby_gem("commonmarker"))
 end


### PR DESCRIPTION
By using ~~redcarpet~~ commonmarker to render gfm-compatible markdown (for readme docs). 
~~This doesn't quite work yet because I can't figure out how to tell redcarpet to use gfm.~~

Fixes https://github.com/JuliaDocs/DocumentationGenerator.jl/issues/19.