### PR TITLE
Clear icon and functionality included

### DIFF
--- a/landingpage/src/App.vue
+++ b/landingpage/src/App.vue
@@ -95,12 +95,13 @@
         :loading="searchLoading"
         single-line
         flat
-        clearable
         ref="searchField"
         @keyup.13="getfilterList"
         @focus="searchFocused = true"
         @blur="onBlurSearch"
-      />
+      >
+        <v-icon slot="append" v-show="search != ''" @click="handleClear">clear</v-icon>
+      </v-text-field>
       <v-btn
         class="pr-0 pl-0"
         v-show="$vuetify.breakpoint.xs && !showSearch"
@@ -401,6 +402,11 @@ export default {
         }
         resolve(pkgs)
       })
+    },
+    handleClear (event){
+      if(this.searchLoading == false){
+        this.search = '';
+      }
     },
     onBlurSearch (val) {
       this.showSearch = false


### PR DESCRIPTION
`clearable` props was removed from the search input field and included a custom clear icon with functionality . This is done because `clearable`props is replacing the search input field with some value(may be `null` but not sure) by which the default view is being affected.
Tried to control the `clearable` by `@click:clear=" search = ' ' " ` but still it did not set the `search` value to empty. 