### PR TITLE
Store Package owner value even if github auth fails

### DIFF
--- a/src/worker_work.jl
+++ b/src/worker_work.jl
@@ -144,7 +144,6 @@ function package_metadata(uuid, name, url, version, buildpath)
 
     @info("Querying metadata for $name")
     try
-        gh_auth = authenticate(readchomp(GIT_TOKEN_FILE))
         matches = match(r".*/(.*)/(.*(?:\.jl)?)(?:.git)?$", url)
         if isnothing(matches) && name == "julia"
             repo_owner = "JuliaLang"
@@ -153,13 +152,14 @@ function package_metadata(uuid, name, url, version, buildpath)
             repo_owner = matches[1]
             repo_name = matches[2]
         end
+        meta["owner"] = repo_owner
+        gh_auth = authenticate(readchomp(GIT_TOKEN_FILE))
         repo_info = repo(repo_owner * "/" * repo_name, auth = gh_auth)
         meta["description"] = something(repo_info.description, "")
         meta["stargazers_count"]  = something(repo_info.stargazers_count, 0)
         meta["license"], meta["license_url"] = license(joinpath(buildpath, "_packagesource"))
         topics_dict, page = topics(repo_info, auth = gh_auth)
         meta["tags"] = something(topics_dict["names"], [])
-        meta["owner"] = repo_owner
         meta["contributors"] = contributor_user.(contributors(repo_info, auth = gh_auth)[1])
     catch err
         @error(string("Couldn't get info for ", url), error = err)


### PR DESCRIPTION
* Store owner in meta.toml even when git auth fails