### PR TITLE
WIP: search in filtered packages

### DIFF
--- a/landingpage/src/components/FilterCard.vue
+++ b/landingpage/src/components/FilterCard.vue
@@ -29,17 +29,21 @@
       <v-card-text>
         <div class="pb-1">
           <a
-          class="a-color"
-          :href="'https://github.com/' + data.owner + '/' + data.pkg_actual_path + '#L' + data.line"
-          target="_blank"
-          v-html="data.pkg_display_path"
+            class="a-color"
+            :href="'https://github.com/' + data.owner + '/' + data.pkg_actual_path + '#L' + data.line"
+            target="_blank"
+            v-html="data.pkg_display_path"
           />
         </div>
         <!-- Only for symbol search. Begins -->
-        <div v-if="data.usage"class="pb-1">{{data.packagename}} ( {{data.type}} 
+        <div
+          v-if="data.usage"
+          class="pb-1"
+        >
+          {{ data.packagename }} ( {{ data.type }}
           <span v-if="data.usage == 'use'"> usage </span>
           <span v-if="data.usage == 'define'"> definition </span> )
-        </div >
+        </div>
         <!-- Only for symbol search. Ends-->
         <code>
           <span>{{ data.line }}</span>
@@ -81,7 +85,7 @@ code{
   font-size: 90%;
   width: 100%;
 
-  box-shadow: 0px 0px;  
+  box-shadow: 0px 0px;
 }
 .theme--dark .a-color{
   color: #82b1ff;

--- a/landingpage/src/components/PackageCard.vue
+++ b/landingpage/src/components/PackageCard.vue
@@ -5,21 +5,38 @@
         class="pb-0 pt-3"
         primary-title
       >
-        <div>
-          <span>
-            <h3 class="headline mb-0">
-              <span class="pkg-owner">
-                {{ details.metadata.owner }}
-              </span>
-              <span class="pkg-owner">
-                /
-              </span>
-              <span class="pkg-name">
-                {{ details.name }}
-              </span>
-            </h3>
-          </span>
-        </div>
+        <v-layout row>
+          <h3 class="headline mb-0">
+            <span class="pkg-owner">
+              {{ details.metadata.owner }}
+            </span>
+            <span class="pkg-owner">
+              /
+            </span>
+            <span class="pkg-name">
+              {{ details.name }}
+            </span>
+          </h3>
+          <v-spacer />
+          <v-tooltip left>
+            <template v-slot:activator="{ on }">
+              <v-btn
+                flat
+                color="grey"
+                target="_blank"
+                icon
+                small
+                :href="details.repo"
+                v-on="on"
+              >
+                <v-icon small>
+                  info
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Build information</span>
+          </v-tooltip>
+        </v-layout>
       </v-card-title>
 
       <v-card-text class="pb-1">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/61289657-1ccdea00-a7ca-11e9-98d1-29b569f6e892.png)

Open questions:
- If you change the filter after having searched, should that retrigger the search or push you back to the landing page?
- How should the search query in the url look? Probably makes the most sense to include all packages we're searching in, but that could get very long (39 chars per package times 2000 packages is way too long to be useful). So we either compress that list of packages or only put the actual filter queries into the URL.