### PR TITLE
Fix: Unable to load deps on subprocesses

### DIFF
--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -125,6 +125,16 @@ function start_builder(package, version;
 
     thisproject = normpath(joinpath(@__DIR__, ".."))
 
+    current_project = Base.active_project()
+    project_file = joinpath(thisproject, "Project.toml")
+    manifest_file = joinpath(thisproject, "Manifest.toml")
+    if !isfile(manifest_file)
+        Pkg.activate(thisproject);
+        chmod(project_file, 0o660)
+        Pkg.instantiate()
+        Pkg.activate(current_project);
+    end
+
     cmd = ```
         $(juliacmd)
             --project="$(thisproject)"

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -123,17 +123,7 @@ function start_builder(package, version;
 
     logfile = joinpath(logpath, "$(name)-$(uuid)-$(version).log")
 
-    thisproject = normpath(joinpath(@__DIR__, ".."))
-
-    current_project = Base.active_project()
-    project_file = joinpath(thisproject, "Project.toml")
-    manifest_file = joinpath(thisproject, "Manifest.toml")
-    if !isfile(manifest_file)
-        Pkg.activate(thisproject);
-        chmod(project_file, 0o660)
-        Pkg.instantiate()
-        Pkg.activate(current_project);
-    end
+    thisproject = Base.active_project()
 
     cmd = ```
         $(juliacmd)


### PR DESCRIPTION
- occurs when main process's environment is not DocumentationGenerator's base environment.
