### PR TITLE
[WIP] Handle cases where loading packages breaks generation

### DIFF
--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -55,6 +55,8 @@ function build_package_docs(packagespec::Pkg.Types.PackageSpec, buildpath, regis
             build_git_docs(packagespec, buildpath, uri; src_prefix=src_prefix, href_prefix=href_prefix)
         elseif type == "vendored"
             build_local_docs(packagespec, buildpath, uri; src_prefix=src_prefix, href_prefix=href_prefix)
+        elseif type == "vendored-no-load"
+            build_local_docs(packagespec, buildpath, uri; src_prefix=src_prefix, href_prefix=href_prefix, load_package=false)
         else
             @error("Invalid doctype specified: $(type).")
             Dict(

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -80,7 +80,7 @@ function maybe_redirect(uri)
     return uri
 end
 
-function build_local_docs(packagespec, buildpath, uri, pkgroot = nothing; gitdirdocs = false, src_prefix="", href_prefix="")
+function build_local_docs(packagespec, buildpath, uri, pkgroot = nothing; gitdirdocs = false, src_prefix="", href_prefix="", load_package = true)
     uri = something(uri, "docs")
     mktempdir() do envdir
         pkgname = packagespec.name
@@ -99,8 +99,11 @@ function build_local_docs(packagespec, buildpath, uri, pkgroot = nothing; gitdir
             pkgfile = Base.find_package(pkgname)
             pkgroot = normpath(joinpath(pkgfile, "..", ".."))
         end
-        mod = try_use_package(packagespec)
-
+        mod = if load_package
+            try_use_package(packagespec)
+        else
+            nothing
+        end
         # actual Documenter docs
         try
             for docdir in joinpath.(pkgroot, unique([uri, "docs", "doc"]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,15 @@ end
             success = [true],
             doctype = ["documenter"],
             using_failed = [false]
+        ),
+        (
+            name = "Tetris",
+            uuid = "d02b474b-c6a0-45b1-beee-9a2049fa00e6",
+            url = "https://github.com/mossr/Tetris.jl/",
+            versions = [v"1.0.0"],
+            installs = [true],
+            success = [true],
+            doctype = ["fallback_autodocs"],
         )
     ]
 


### PR DESCRIPTION
Introduces a new doctype `vendored-no-load`  which skips package loading during generation and falls back to readme. Fixes https://github.com/JuliaDocs/DocumentationGenerator.jl/issues/159 and https://juliahub.com/ui/Packages?q=Glibc_jll. 

Note: PR tests will fail since we don't have the test package in DocumentationGeneratorRegistry yet.

