### PR TITLE
 Add DOCGEN_GITHUB_AUTH_TOKEN to set GitHub token 

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -40,13 +40,14 @@ function update_metadata(packagespec, url, repo_owner, repo_name)
     token = if isfile(authpath)
         readchomp(authpath)
     else
-        get(ENV,"DOCGEN_GITHUB_AUTH_TOKEN", "")
+        get(ENV, "DOCGEN_GITHUB_AUTH_TOKEN", "")
     end
 
     if isempty(token)
         @warn("No GitHub token found. Skipping metadata retrieval")
         return meta
     end
+
     if !occursin("github.com", url)
         @warn("Can't retrieve metadata (not hosted on GitHub).")
         return meta

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -37,19 +37,23 @@ function update_metadata(packagespec, url, repo_owner, repo_name)
         joinpath(@__DIR__, "gh_auth.txt")
     end
 
-    if !isfile(authpath)
-        @warn("No GitHub token found. Skipping metadata retrieval.")
-        return meta
+    token if isfile(authpath)
+        readchomp(authpath)
+    else
+        get(ENV,"DOCGEN_GITHUB_AUTH_TOKEN", "")
     end
 
+    if isempty(token)
+        @warn("No GitHub token found. Skipping metadata retrieval")
+        return meta
+    end
     if !occursin("github.com", url)
         @warn("Can't retrieve metadata (not hosted on GitHub).")
         return meta
     end
-
     @info("Querying metadata.")
     try
-        gh_auth = authenticate(readchomp(authpath))
+        gh_auth = authenticate(token)
         repo_info = repo(repo_owner * "/" * repo_name, auth = gh_auth)
         meta["description"] = something(repo_info.description, "")
         meta["stargazers_count"]  = something(repo_info.stargazers_count, 0)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -37,7 +37,7 @@ function update_metadata(packagespec, url, repo_owner, repo_name)
         joinpath(@__DIR__, "gh_auth.txt")
     end
 
-    token if isfile(authpath)
+    token = if isfile(authpath)
         readchomp(authpath)
     else
         get(ENV,"DOCGEN_GITHUB_AUTH_TOKEN", "")


### PR DESCRIPTION
Alternative to `DOCGEN_GITHUB_AUTH_FILE`, set the token directly as env variable