### PR TITLE
Add ability to inspect exception if fetching repo metadata fails

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -59,6 +59,7 @@ function update_metadata(packagespec, url, repo_owner, repo_name)
         return meta
     end
     @info("Querying metadata.")
+    gh_auth = authenticate(token)
     repo_info = repo(repo_owner * "/" * repo_name, auth = gh_auth)
     meta["description"] = something(repo_info.description, "")
     meta["stargazers_count"]  = something(repo_info.stargazers_count, 0)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -16,20 +16,22 @@ end
 
 function package_metadata(packagespec, url)
     meta = init_metadata(packagespec, url)
+    new_metadata = try
+        fetch_updated_metadata(packagespec, url)
+    catch ex
+        @error(string("Couldn't get info for ", url), error = ex)
+        Dict()
+    end
+    return merge!(meta, new_metadata)
+end
 
+function fetch_updated_metadata(packagespec, url)
     rmatch = match(r".*/(.*)/(.*?(?:\.jl)?)(?:.git)?$", url)
     if rmatch !== nothing
         meta["owner"] = rmatch[1]
         meta["name"] = rmatch[2]
     end
-    updated_metadata = try
-        update_metadata(packagespec, url, rmatch[1], rmatch[2])
-    catch ex
-        @error(string("Couldn't get info for ", url), error = ex)
-        Dict()
-    end
-    merge!(meta, updated_metadata)
-    return meta
+    return update_metadata(packagespec, url, rmatch[1], rmatch[2])
 end
 
 function update_metadata(packagespec, url, repo_owner, repo_name)


### PR DESCRIPTION
- Caller should be able to retry metadata fetch based on the exception
- fixes: pkgeval data parsing issue change in index type(package `uuid` to `name`)