### PR TITLE
Call `Pkg.build()` to work around TimeZones.jl#331

### DIFF
--- a/src/rundocumenter.jl
+++ b/src/rundocumenter.jl
@@ -21,6 +21,11 @@ try
 catch err
     @error("Error while developing parent directory $(pkgdir):", err)
 end
+try
+    Pkg.build()
+catch err
+    @error("Error while building packages:", err)
+end
 Pkg.status()
 
 documenter_version = v"0.24.10"


### PR DESCRIPTION
TimeZones has a strange heisenbug where it will sometimes fail to build the TZ data, often appearing in headless systems such as CI and documentation generation.  Apparently a workaround is to explicitly call `Pkg.build()` after instantiation to ensure a successful build, as noted by @iamed2 in https://github.com/JuliaTime/TimeZones.jl/issues/331#issuecomment-1051347453.