### PR TITLE
fix: eval into module

### DIFF
--- a/src/rundocumenter.jl
+++ b/src/rundocumenter.jl
@@ -46,5 +46,5 @@ task_local_storage()[:SOURCE_PATH] = makefile
 cd(docsdir) do
     @info("Evaluating the following `make` expr:")
     @info(expr)
-    eval(expr)
+    Base.eval(Module(), expr)
 end


### PR DESCRIPTION
to give a clean namespace for user provided expression