### PR TITLE
Pick up docstrings from submodules in fallback docs

### DIFF
--- a/src/builders.jl
+++ b/src/builders.jl
@@ -326,7 +326,7 @@ end
 function submodules(root::Module, seen = Set{Module}())
     push!(seen, root)
     for name in names(root, all=true)
-        if Base.isidentifier(name) && isdefined(root, name) && Base.!isdeprecated(root, name)
+        if Base.isidentifier(name) && isdefined(root, name) && !Base.isdeprecated(root, name)
             object = getfield(root, name)
             if isa(object, Module) && !(object in seen) && parentmodule(object::Module) == root
                 submodules(object, seen)

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -304,7 +304,7 @@ function find_readme(pkgroot)
 end
 
 function add_autodocs(docsdir, mod)
-    module_list = join((string(m) for m in Documenter.submodules(PACKAGE_MODULE)), ", ")
+    module_list = join((string(m) for m in Documenter.submodules(mod)), ", ")
     open(joinpath(docsdir, "autodocs.md"), "w") do io
         println(io, """
         ```@autodocs

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -304,7 +304,7 @@ function find_readme(pkgroot)
 end
 
 function add_autodocs(docsdir, mod)
-    module_list = join((string(m) for m in Documenter.submodules(mod)), ", ")
+    module_list = join((string(m) for m in submodules(mod)), ", ")
     open(joinpath(docsdir, "autodocs.md"), "w") do io
         println(io, """
         ```@autodocs
@@ -312,6 +312,27 @@ function add_autodocs(docsdir, mod)
         ```
         """)
     end
+end
+
+# Borrowed from Documenter.jl (MIT)
+function submodules(modules::Vector{Module})
+    out = Set{Module}()
+    for each in modules
+        submodules(each, out)
+    end
+    out
+end
+function submodules(root::Module, seen = Set{Module}())
+    push!(seen, root)
+    for name in names(root, all=true)
+        if Base.isidentifier(name) && isdefined(root, name) && !isdeprecated(root, name)
+            object = getfield(root, name)
+            if isa(object, Module) && !(object in seen) && parentmodule(object::Module) == root
+                submodules(object, seen)
+            end
+        end
+    end
+    return seen
 end
 
 function monkeypatchdocsearch(packagespec, buildpath)

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -304,10 +304,11 @@ function find_readme(pkgroot)
 end
 
 function add_autodocs(docsdir, mod)
+    module_list = join((string(m) for m in Documenter.submodules(PACKAGE_MODULE)), ", ")
     open(joinpath(docsdir, "autodocs.md"), "w") do io
         println(io, """
         ```@autodocs
-        Modules = [$(Symbol(mod))]
+        Modules = [$module_list]
         ```
         """)
     end

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -325,7 +325,7 @@ end
 function submodules(root::Module, seen = Set{Module}())
     push!(seen, root)
     for name in names(root, all=true)
-        if Base.isidentifier(name) && isdefined(root, name) && !isdeprecated(root, name)
+        if Base.isidentifier(name) && isdefined(root, name) && Base.!isdeprecated(root, name)
             object = getfield(root, name)
             if isa(object, Module) && !(object in seen) && parentmodule(object::Module) == root
                 submodules(object, seen)


### PR DESCRIPTION
Currently, in the auto-generated fallback docs, we don't pick up docstrings from submodules. E.g.: https://juliahub.com/ui/Code/docs/Pluto/OJqMt/0.19.22.log#L135

This is because we only give the at-autodocs block the top level module, but you need to list each module the explicitly. This patch is a proof of concept example of how we could fix that (I haven't run the code actually).

This relies on an internal Documenter function,`Documenter.submodules`, which lives [here](https://github.com/JuliaDocs/Documenter.jl/blob/b50d74bc02d6883ef36aa19f19129e7a2d675ea9/src/utilities/utilities.jl#L220-L241). I believe the Documenter module is, in principle, accessible. But we could also copy the implementation here.