### PR TITLE
fix: turn off pkgimages during generation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -285,6 +285,7 @@ function start_builder(package, version;
             --project="$(thisproject)"
             --color=no
             --compiled-modules=no
+            --pkgimages=no
             -O0
             $workerfile
             $uuid

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -280,13 +280,15 @@ function start_builder(package, version;
     thisproject = Base.active_project()
 
     ## api_url needs to be set to "-", since empty string should not be passed as CLI argument
-    pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n" : ""
+    pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no" : ""
+
     cmd = ```
         $(juliacmd)
             --project="$(thisproject)"
             --color=no
             --compiled-modules=no
-            $(pkgimagesopt)-O0
+            $(split(pkgimagesopt))
+            -O0
             $workerfile
             $uuid
             $name

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -280,7 +280,7 @@ function start_builder(package, version;
     thisproject = Base.active_project()
 
     ## api_url needs to be set to "-", since empty string should not be passed as CLI argument
-    pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n": ""
+    pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n" : ""
     cmd = ```
         $(juliacmd)
             --project="$(thisproject)"

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -287,7 +287,7 @@ function start_builder(package, version;
             --project="$(thisproject)"
             --color=no
             --compiled-modules=no
-            $(split(pkgimagesopt))
+            $([pkgimagesopt])
             -O0
             $workerfile
             $uuid

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -280,13 +280,13 @@ function start_builder(package, version;
     thisproject = Base.active_project()
 
     ## api_url needs to be set to "-", since empty string should not be passed as CLI argument
+    pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n": ""
     cmd = ```
         $(juliacmd)
             --project="$(thisproject)"
             --color=no
             --compiled-modules=no
-            --pkgimages=no
-            -O0
+            $(pkgimagesopt)-O0
             $workerfile
             $uuid
             $name

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -204,7 +204,7 @@ function build_documenter(packagespec, docdir)
             @info("Using $(makefile) to generate Documenter docs.")
         end
         _, builddir = fix_makefile(makefile)
-        pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n": ""
+        pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n" : ""
         cmd = ```
             $(first(Base.julia_cmd()))
                 --project="$(docdir)"

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -209,7 +209,7 @@ function build_documenter(packagespec, docdir)
             $(first(Base.julia_cmd()))
                 --project="$(docdir)"
                 --compiled-modules=no
-                $(split(pkgimagesopt))
+                $([pkgimagesopt])
                 -O0
                 $(rundcocumenter)
                 $(pkgdir)

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -204,13 +204,12 @@ function build_documenter(packagespec, docdir)
             @info("Using $(makefile) to generate Documenter docs.")
         end
         _, builddir = fix_makefile(makefile)
-
+        pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n": ""
         cmd = ```
             $(first(Base.julia_cmd()))
                 --project="$(docdir)"
                 --compiled-modules=no
-                --pkgimages=no
-                -O0
+                $(pkgimagesopt)-O0
                 $(rundcocumenter)
                 $(pkgdir)
                 $(makefile)

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -209,6 +209,7 @@ function build_documenter(packagespec, docdir)
             $(first(Base.julia_cmd()))
                 --project="$(docdir)"
                 --compiled-modules=no
+                --pkgimages=no
                 -O0
                 $(rundcocumenter)
                 $(pkgdir)

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -204,12 +204,13 @@ function build_documenter(packagespec, docdir)
             @info("Using $(makefile) to generate Documenter docs.")
         end
         _, builddir = fix_makefile(makefile)
-        pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no\n" : ""
+        pkgimagesopt = VERSION >= v"1.9" ? "--pkgimages=no" : ""
         cmd = ```
             $(first(Base.julia_cmd()))
                 --project="$(docdir)"
                 --compiled-modules=no
-                $(pkgimagesopt)-O0
+                $(split(pkgimagesopt))
+                -O0
                 $(rundcocumenter)
                 $(pkgdir)
                 $(makefile)


### PR DESCRIPTION
Since we are unlikely load the packages again