### PR TITLE
Run Documenter in Main

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Highlights = "eafb193a-b7ab-5a9e-9068-77385905fa72"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "DocumentationGenerator"
 uuid = "8f0d3306-d70b-5309-b898-24bb6ab47850"
 authors = ["Sebastian Pfitzner <pfitzseb@physik.hu-berlin.de>", "Simon Danisch <sdanisch@gmail.com>", "Venkatesh Dayananda <venkatesh@juliacomputing.com>"]
 repo = "https://github.com/JuliaDocs/DocumentationGenerator.jl.git"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/rundocumenter.jl
+++ b/src/rundocumenter.jl
@@ -1,50 +1,57 @@
-if length(ARGS) == 2
-    pkgdir = ARGS[1]
-    makefile = ARGS[2]
-else
-    makefile = joinpath(pwd(), "make.jl")
-    pkgdir = normpath(joinpath(pwd(), ".."))
-    @info("No directory specified. Falling back to pkgdir=`$(pkgdir)` and makefile=`$(makefile)`.")
-end
-docsdir = dirname(makefile)
-
-using Pkg
-
-include(joinpath(@__DIR__, "utils", "rewrite.jl"))
-try
-    Pkg.instantiate()
-catch err
-    @error("Error while instantiating docs directory:", err)
-end
-try
-    Pkg.develop(PackageSpec(path=pkgdir))
-catch err
-    @error("Error while developing parent directory $(pkgdir):", err)
-end
-Pkg.status()
-
-documenter_version = v"0.24.10"
-try
-    manifest = joinpath(docsdir, "Manifest.toml")
-    if isfile(manifest)
-        pm = Pkg.TOML.parsefile(manifest)
-        global documenter_version = VersionNumber(first(pm["Documenter"])["version"])
-    else
-        @warn("No Mainfest.toml found at `$(manifest)`. Defaulting to $(documenter_version).")
+let anonymous_module = Module()
+    @eval anonymous_module begin
+        import Pkg, TOML
     end
-catch err
-    @error(exception = err)
-end
+    Base.include(anonymous_module, joinpath(@__DIR__, "utils", "rewrite.jl"))
+    @eval anonymous_module begin
+        function main(args)
+            if length(args) == 2
+                pkgdir = args[1]
+                makefile = args[2]
+            else
+                makefile = joinpath(pwd(), "make.jl")
+                pkgdir = normpath(joinpath(pwd(), ".."))
+                @info("No directory specified. Falling back to pkgdir=`$(pkgdir)` and makefile=`$(makefile)`.")
+            end
+            docsdir = dirname(makefile)
 
-@info("Detected Documenter version $(documenter_version).")
+            try
+                Pkg.instantiate()
+            catch err
+                @error("Error while instantiating docs directory:", err)
+            end
+            try
+                Pkg.develop(Pkg.PackageSpec(path=pkgdir))
+            catch err
+                @error("Error while developing parent directory $(pkgdir):", err)
+            end
+            Pkg.status()
 
-expr, bpath = fix_makefile(makefile, documenter_version)
+            documenter_version = v"0.24.10"
+            try
+                manifest = joinpath(docsdir, "Manifest.toml")
+                if isfile(manifest)
+                    pm = TOML.parsefile(manifest)
+                    global documenter_version = VersionNumber(first(pm["Documenter"])["version"])
+                else
+                    @warn("No Mainfest.toml found at `$(manifest)`. Defaulting to $(documenter_version).")
+                end
+            catch err
+                @error(exception = err)
+            end
 
+            @info("Detected Documenter version $(documenter_version).")
 
-@info("`cd`ing to `$(docsdir)` and setting `tls[:SOURCE_PATH]` to `$(makefile)`.")
-task_local_storage()[:SOURCE_PATH] = makefile
-cd(docsdir) do
-    @info("Evaluating the following `make` expr:")
-    @info(expr)
-    Base.eval(Module(), expr)
+            expr, bpath = fix_makefile(makefile, documenter_version)
+
+            @info("`cd`ing to `$(docsdir)` and setting `tls[:SOURCE_PATH]` to `$(makefile)`.")
+            task_local_storage()[:SOURCE_PATH] = makefile
+            cd(docsdir) do
+                @info("Evaluating the following `make` expr:")
+                @info(expr)
+                Base.eval(Main, expr)
+            end
+        end
+    end
+    anonymous_module.main(ARGS)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,6 +246,18 @@ end
             success = [true],
             doctype = ["documenter"],
             using_failed = [false]
+        ),
+        (
+            name = "HDF5",
+            url = "https://github.com/JuliaIO/HDF5.jl.git",
+            uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f",
+            versions = [v"0.17.0"],
+            server_type = "github",
+            api_url="",
+            installs = [true],
+            success = [true],
+            doctype = ["documenter"],
+            using_failed = [false]
         )
     ]
 


### PR DESCRIPTION
Following #184 we evaluate the `make.jl` script into a temporary module, but Documenter generally assumes that things are present in `Main` (e.g. when referring to them in at-meta blocks). This flips the `rundocumenter.jl` script around, putting all our code into an anonymous module, but `@eval`-ing the updated `make.jl` expression into `Main`. Fix #199.

cc @vdayanand @pfitzseb 