### PR TITLE
fix: don't re-install Documenter in main environment

### DIFF
--- a/src/builders.jl
+++ b/src/builders.jl
@@ -263,8 +263,6 @@ function build_readme_docs(pkgname, pkgroot, docsdir, mod, src_prefix, href_pref
     end
 
     @eval Module() begin
-        using Pkg
-        Pkg.add("Documenter")
         using Documenter
         makedocs(
             format = Documenter.HTML(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,17 +155,6 @@ end
         ),
         # git-dir docs
         (
-            name = "Phylo",
-            url = "https://github.com/richardreeve/Phylo.jl.git",
-            uuid = "aea672f4-3940-5932-aa44-993d1c3ff149",
-            versions = [v"0.4.21"],
-            installs = [true],
-            success = [true],
-            server_type = "github",
-            api_url="",
-            doctype = ["documenter"],
-        ),
-        (
             name = "OpenSpiel_jll",
             url = "https://github.com/JuliaBinaryWrappers/OpenSpiel_jll.jl.git",
             uuid = "bd10a763-4654-5023-a028-c4918c6cd33e",


### PR DESCRIPTION
It looks like we're automatically pulling in Documenter 1.0 with these lines, and this is now causing, at least, test failures: https://github.com/JuliaDocs/DocumentationGenerator.jl/actions/runs/6183787531/job/16911998356

I am not 100% sure why the readme build would fail with Documenter 1.0 at the moment, but I suspect it's because of AbstractTrees incompatibility (#180). But regardless -- it should not be necessary to reinstall Documenter in this eval, since it already exists in the DocumentationGenerator environment.