### PR TITLE
Support registry hosted under JuliaComputing

### DIFF
--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -93,7 +93,7 @@ function build_documentation(
         false
     end
 
-    regpath = get_registry(basepath, sync = sync_registry)
+    regpath = get_registry(basepath; sync = sync_registry)
     process_queue = []
 
     # make sure registry is updated *before* we start multiple processes that might try that at the same time

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -47,6 +47,11 @@ function _clone_registry(registry::AbstractString; destdir::AbstractString)
         end
         mv(tempclone, destdir, force = true)
     end
+    tomlpath = joinpath(destdir, "Registry.toml")
+    if !isfile(tomlpath)
+        error("Registry clone succesful, but Registry.toml missing\n at $(tomlpath)")
+    end
+    return tomlpath
 end
 
 """

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -38,7 +38,10 @@ end
 function _clone_registry(registry::AbstractString; destdir::AbstractString)
     mktempdir() do temp
         tempclone = joinpath(temp, "registry")
-        run(`git clone --depth=1 $(registry) $(tempclone)`)
+        git = Sys.which("git")
+        isnothing(git) && error("Sys.which was unable to find the 'git' binary")
+        git = addenv(`$git`, "GIT_TERMINAL_PROMPT" => "0")
+        run(`$git clone --depth=1 $(registry) $(tempclone)`)
         if !isfile(joinpath(tempclone, "Registry.toml"))
             error("Failed to clone registry: Registry.toml missing")
         end

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -4,7 +4,7 @@ const DOCS_REGISTRIES = [
 ]
 
 """
-    get_registry(basepath; registry=DOCS_REGISTRY, sync = true)
+    get_registry(basepath; sync = true)
 
 Clone the DocumentationGenerator registry into `basepath`. No download will occur if `sync == false`
 and the registry already exists.


### PR DESCRIPTION
Adds a logic where it tries to clone the registry first from

- `https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git`

and if that fails, it clones from the current

- `https://github.com/JuliaDocs/DocumentationGeneratorRegistry.git`

Currently, looks like this when run:

```
julia> DocumentationGenerator.get_registry(pwd())
Cloning into '/tmp/jl_UF11kJ/registry'...
fatal: could not read Username for 'https://github.com': terminal prompts disabled
┌ Warning: Unable to clone DocumentationGeneratorRegistry
│   registry = "https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git"
│   exception =
│    failed process: Process(setenv(`/usr/bin/git clone --depth=1 https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git /tmp/jl_UF11kJ/registry`,[...]), ProcessExited(128)) [128]
│
└ @ DocumentationGenerator ~/juliadocs/clones/DocumentationGenerator.jl/src/registry.jl:21
Cloning into '/tmp/jl_MIfrso/registry'...
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 14 (delta 0), reused 7 (delta 0), pack-reused 0
Receiving objects: 100% (14/14), 8.36 KiB | 8.36 MiB/s, done.
"/home/mortenpi/juliadocs/clones/DocumentationGenerator.jl/DocumentationGeneratorRegistry"
```