### PR TITLE
Prefer JuliaDocs registry in 0.7, but fall back to JuliaComputing

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,3 +1,7 @@
+# The registry cloning URLs are tried in order. Currently (on the 0.7 branch),
+# we still try to clone the registry first from JuliaDocs, remaining consistent
+# with the earlier releases. But we will fall back to the JuliaComputing URL
+# if it stops working.
 const DOCS_REGISTRIES = [
     "https://github.com/JuliaDocs/DocumentationGeneratorRegistry.git",
     "https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git",

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,6 +1,6 @@
 const DOCS_REGISTRIES = [
-    "https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git",
     "https://github.com/JuliaDocs/DocumentationGeneratorRegistry.git",
+    "https://github.com/JuliaComputing/DocumentationGeneratorRegistry.git",
 ]
 
 """


### PR DESCRIPTION
Trivial follow-up to #213: it just occurred to me that it would make more sense if it prefers JuliaDocs on the 0.7 branch. I.e it will first try to clone from JuliaDocs, and if that fails, it goes to JuliaComputing. This means:

* Before the move, the first attempt will succeed, so it behaves like before.
* After the move, it will likely also just keep working.
* But if cloning from JuliaDocs no longer works, then it will clone from JuliaComputing and still keep working.

In 0.8, which we'll tag after the move, we can either change it around again, or remove JuliaDocs altogether. 