### PR TITLE
Run worker project in isolated environment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "DocumentationGenerator"
 uuid = "8f0d3306-d70b-5309-b898-24bb6ab47850"
 authors = ["Sebastian Pfitzner <pfitzseb@physik.hu-berlin.de>", "Simon Danisch <sdanisch@gmail.com>", "Venkatesh Dayananda <venkatesh@juliacomputing.com>"]
 repo = "https://github.com/JuliaDocs/DocumentationGenerator.jl.git"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -250,10 +250,10 @@ function with_juliaenv(func, temp_path=tempname())
     result = try
         func()
     catch ex
-        Pkg.activate(current_project)
         rethrow()
+    finally
+        Pkg.activate(current_project)
     end
-    Pkg.activate(current_project)
     return result
 end
 

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -247,14 +247,13 @@ end
 function with_juliaenv(func, temp_path=tempname())
     current_project = Base.active_project()
     Pkg.activate(temp_path)
-    result = try
+    try
         func()
     catch ex
         rethrow()
     finally
         Pkg.activate(current_project)
     end
-    return result
 end
 
 function start_builder(package, version;


### PR DESCRIPTION
- worker process will only have the packages which it needs rather inheriting the top level project
- Long term fix: refactor workerfile to not depend on DocumentationGenerator
