### PR TITLE
fix: also unset `repo` in the packages `make.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "DocumentationGenerator"
 uuid = "8f0d3306-d70b-5309-b898-24bb6ab47850"
 authors = ["Sebastian Pfitzner <pfitzseb@physik.hu-berlin.de>", "Simon Danisch <sdanisch@gmail.com>", "Venkatesh Dayananda <venkatesh@juliacomputing.com>"]
 repo = "https://github.com/JuliaDocs/DocumentationGenerator.jl.git"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/utils/rewrite.jl
+++ b/src/utils/rewrite.jl
@@ -47,6 +47,7 @@ function fix_makefile(makefile, documenter_version = v"0.24")
             has_doctest = false
             has_root = false
             has_remotes = false
+            has_repo = false
             html = documenter_version < v"0.21" ? QuoteNode(:html) : :(Documenter.HTML())
 
             fixkwarg = argument -> begin
@@ -84,6 +85,10 @@ function fix_makefile(makefile, documenter_version = v"0.24")
                     if name == :remotes
                         has_remotes = true
                         argument.args[2] = nothing
+                    end
+                    if name == :repo
+                        has_repo = true
+                        argument.args[2] = ""
                     end
                     if name == :doctest
                         has_doctest = true
@@ -125,6 +130,9 @@ function fix_makefile(makefile, documenter_version = v"0.24")
             end
             if !has_remotes
                 push!(new_args, Expr(:kw, :remotes, nothing))
+            end
+            if !has_repo
+                push!(new_args, Expr(:kw, :repo, ""))
             end
 
             elem = Expr(:call, new_args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,6 +247,21 @@ end
             success = [true],
             doctype = ["documenter"],
             using_failed = [false]
+        ),
+        (
+            # This Horus.jl version has the `repo` keyword set in make.jl,
+            # but uses Documenter 1.0+, so we need to unset both `repo` and
+            # `remotes` for it to build correctly.
+            name = "Horus",
+            url = "https://github.com/aviks/Horus.jl.git",
+            uuid = "bc501ac0-6d4c-4855-b16f-b0e03415614f",
+            versions = [v"0.1.0"],
+            server_type = "github",
+            api_url="",
+            installs = [true],
+            success = [true],
+            doctype = ["documenter"],
+            using_failed = [false]
         )
     ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,21 +248,35 @@ end
             doctype = ["documenter"],
             using_failed = [false]
         ),
-        (
-            # This Horus.jl version has the `repo` keyword set in make.jl,
-            # but uses Documenter 1.0+, so we need to unset both `repo` and
-            # `remotes` for it to build correctly.
-            name = "Horus",
-            url = "https://github.com/aviks/Horus.jl.git",
-            uuid = "bc501ac0-6d4c-4855-b16f-b0e03415614f",
-            versions = [v"0.1.0"],
-            server_type = "github",
-            api_url="",
-            installs = [true],
-            success = [true],
-            doctype = ["documenter"],
-            using_failed = [false]
-        )
+        # This Horus.jl version has the `repo` keyword set in make.jl,
+        # but uses Documenter 1.0+, so we need to unset both `repo` and
+        # `remotes` for it to build correctly.
+        let p = (
+                name = "Horus",
+                url = "https://github.com/aviks/Horus.jl.git",
+                uuid = "bc501ac0-6d4c-4855-b16f-b0e03415614f",
+                versions = [v"0.1.0"],
+                server_type = "github",
+                api_url="",
+            )
+            # Horus v0.1.0 requires at least Julia 1.9
+            if VERSION >= v"1.9"
+                (;
+                    p...,
+                    installs = [true],
+                    success = [true],
+                    doctype = ["documenter"],
+                    using_failed = [false],
+                )
+            else
+                (;
+                    p...,
+                    installs = [false],
+                    success = [false],
+                    doctype = ["missing"],
+                )
+            end
+        end,
     ]
 
     basepath = @__DIR__


### PR DESCRIPTION
After #216, we're setting the `remotes` keyword to `nothing`. But if the user's `make.jl` sets the `repo`, then we'll fail to generate the documentation with:

```
ERROR: LoadError: 
ArgumentError: When `remotes` is set to `nothing`, `repo` must not be set.
```

So this also enforces the `repo = ""` default, to ensure that the documentation builds don't fail.