### PR TITLE
fix: methoderror while reading process output

### DIFF
--- a/src/utils/runners.jl
+++ b/src/utils/runners.jl
@@ -100,6 +100,6 @@ function readstr_buffer(x::IOStream)
     return read(x, String)
 end
 
-function readstr_buffer(x::Base.GenericIOBuffer{Array{UInt8,1}})
+function readstr_buffer(x::IOBuffer)
     return String(take!(x))
 end


### PR DESCRIPTION
IOBuffer alias has changed in 1.11 (`Base.GenericIOBuffer{Array{UInt8, 1}}` -> `Base.GenericIOBuffer{GenericMemory{:not_atomic, UInt8, Core.AddrSpace{Core}(0x00)}}`)