### PR TITLE
fix: child processes are not killed after timeout

### DIFF
--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -156,7 +156,10 @@ function build_documentation(
 
         # wait for all queued processes to finish
         for proc in process_queue
-            wait(proc)
+            pid = getpid(proc)
+            pgid = get_pgid(pid)
+            @info "detected session id for process $(pid): $(pgid)"
+            wait(proc, false)
         end
     end
 

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -156,7 +156,7 @@ function build_documentation(
 
         # wait for all queued processes to finish
         for proc in process_queue
-            t = timedwait(x -> process_running(proc) || process_exited(proc), 20)
+            t = timedwait(() -> process_running(proc) || process_exited(proc), 20)
             t == :timed_out && error("Process failed to start")
             pid = getpid(proc)
             pgid = get_pgid(pid)

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -159,7 +159,11 @@ function build_documentation(
             pid = getpid(proc)
             pgid = get_pgid(pid)
             @info "detected session id for process $(pid): $(pgid)"
-            wait(proc, false)
+            if VERSION < v"1.11"
+                wait(proc)
+            else
+                wait(proc, false)
+            end
         end
     end
 

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -156,6 +156,8 @@ function build_documentation(
 
         # wait for all queued processes to finish
         for proc in process_queue
+            t = timedwait(x -> process_running(proc) || process_exited(proc), 20)
+            t == :timed_out && error("Process failed to start")
             pid = getpid(proc)
             pgid = get_pgid(pid)
             @info "detected session id for process $(pid): $(pgid)"

--- a/src/DocumentationGenerator.jl
+++ b/src/DocumentationGenerator.jl
@@ -156,11 +156,6 @@ function build_documentation(
 
         # wait for all queued processes to finish
         for proc in process_queue
-            t = timedwait(() -> process_running(proc) || process_exited(proc), 20)
-            t == :timed_out && error("Process failed to start")
-            pid = getpid(proc)
-            pgid = get_pgid(pid)
-            @info "detected session id for process $(pid): $(pgid)"
             if VERSION < v"1.11"
                 wait(proc)
             else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,12 +265,7 @@ end
                     using_failed = [false],
                 )
             else
-                (;
-                    p...,
-                    installs = [false],
-                    success = [false],
-                    doctype = ["missing"],
-                )
+                (; p..., installs = [false], success = [false], doctype = ["missing"])
             end
         end,
         (
@@ -296,20 +291,38 @@ end
             success = [true],
             doctype = ["documenter"],
             using_failed = [false],
-        )
+        ),
+        (
+            name = "NetworkDynamics",
+            url = "https://github.com/JuliaDynamics/NetworkDynamics.jl.git",
+            uuid = "22e9dc34-2a0d-11e9-0de0-8588d035468b",
+            versions = [v"0.9.16"],
+            server_type = "github",
+            api_url = "",
+            installs = [true],
+            success = [false],
+            doctype = ["documenter"],
+            using_failed = [false],
+        ),
     ]
 
     basepath = @__DIR__
     rm(joinpath(basepath, "build"), force = true, recursive = true)
 
     DocumentationGenerator.build_documentation(
-        packages, basepath = basepath, filter_versions = identity, processes = 6
+        packages,
+        basepath = basepath,
+        filter_versions = identity,
+        processes = 6,
+        timeout = 300,
     )
 
     build = joinpath(basepath, "build")
     @testset "build folder" begin
         for pkg in packages
-            pkgbuild = joinpath(build, DocumentationGenerator.get_docs_dir(pkg.name, pkg.uuid))
+            !pkg.success[1] && continue
+            pkgbuild =
+                joinpath(build, DocumentationGenerator.get_docs_dir(pkg.name, pkg.uuid))
             @test isdir(pkgbuild)
             @testset "$(pkg.name): $(version)" for (i, version) in enumerate(pkg.versions)
                 log = joinpath(pkgbuild, "$(version).log")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,7 +314,7 @@ end
         basepath = basepath,
         filter_versions = identity,
         processes = 6,
-        timeout = 300,
+        timeout = 600,
     )
 
     build = joinpath(basepath, "build")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,6 @@ const julia = first(Base.julia_cmd())
         """
         proc, _ = DocumentationGenerator.run_with_timeout(`$julia -e $str`, timeout=7)
         wait(proc)
-        @test !success(proc)
         @test !isfile(tempfile)
     end
 
@@ -297,7 +296,7 @@ end
             success = [true],
             doctype = ["documenter"],
             using_failed = [false],
-        ),
+        )
     ]
 
     basepath = @__DIR__


### PR DESCRIPTION
Currently, children processes (spawn by packages) don't kill after timeout. This PR uses process [group](https://www.man7.org/linux/man-pages/man2/setpgid.2.html) to kill them. 
Alternative to https://github.com/JuliaDocs/DocumentationGenerator.jl/pull/231